### PR TITLE
Add script to get language name from language code

### DIFF
--- a/scripts/get_language_name.sh
+++ b/scripts/get_language_name.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <language_code>"
+    exit 1
+fi
+
+language_code=$1
+script_location=$(dirname "$0")
+
+language_name=$(python3 -c "
+import sys
+sys.path.insert(0, '$script_location')
+from git_tools import language_code_map
+print(language_code_map.get('$language_code', ''))
+")
+
+if [ -z "$language_name" ]; then
+    echo "get_language_name: language code $language_code not recognized." >&2
+    exit 1
+fi
+
+echo "$language_name"


### PR DESCRIPTION
This PR adds a script that can used like

```bash
language_name=$(./get_language_name ja)
```

in order to get a  language name from a Crowdin language code. I'm working on github workflows that take two letter language codes as argument and autogenerate PRs to update translations for  a particular language. This script will be used so we put the language name in the PR title instead of the two letter code. 



